### PR TITLE
Draw into terminal

### DIFF
--- a/src/cmd_options.hpp
+++ b/src/cmd_options.hpp
@@ -42,9 +42,9 @@ Options
                      Can be one of: png, jpg, bmp, tga, svg, term
                      If term format is selected, the image will
                      be drawn into the terminal instead of a file.
-                     It's recommended to also specify a maximum
-                     width/height to ensure the resulting image
-                     fits in the terminal.
+                     In that case it's recommended to also specify
+                     a maximum width/height to ensure the resulting
+                     image fits in the terminal.
 )";
 
 void print_usage(const std::string& executable_name) {

--- a/src/cmd_options.hpp
+++ b/src/cmd_options.hpp
@@ -37,8 +37,14 @@ Options
   --adjust-colors    Compute colors based on the maximum occupancy of blocks
                      instead of based on block capacity.
   -f <fmt>
-  --output-format <fmt>  The format of the output image.
-                         Can be on of: png, jpg, bmp, tga, svg
+  --output-format <fmt>
+                     The format of the output image.
+                     Can be one of: png, jpg, bmp, tga, svg, term
+                     If term format is selected, the image will
+                     be drawn into the terminal instead of a file.
+                     It's recommended to also specify a maximum
+                     width/height to ensure the resulting image
+                     fits in the terminal.
 )";
 
 void print_usage(const std::string& executable_name) {
@@ -81,6 +87,7 @@ std::optional<ImageFormat> parse_image_format(std::string format_string) {
         { "jpeg", ImageFormat::jpg },
         { "bmp", ImageFormat::bmp },
         { "tga", ImageFormat::tga },
+        { "term", ImageFormat::term },
     };
 
     for (auto& c : format_string) {

--- a/src/drawing/draw.hpp
+++ b/src/drawing/draw.hpp
@@ -81,7 +81,8 @@ enum class ImageFormat {
     png,
     jpg,
     bmp,
-    tga
+    tga,
+    term
 };
 
 struct ImageConfig {

--- a/src/drawing/term.hpp
+++ b/src/drawing/term.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <drawing/draw.hpp>
+
+#include <ostream>
+
+struct TermDrawer : ImageDrawer {
+
+    void operator()(const Grid& grid, const ImageConfig& config) override {
+        Rgb color;
+
+        std::ostream& out = std::cout;
+
+        size_t max_occupancy = config.adjust_colors ? grid.max_occupancy() : grid.block_capacity();
+
+        for (size_t row = 0; row < grid.rows(); ++row) {
+            for (size_t col = 0; col < grid.cols(); ++col) {
+
+                float density = grid.count_at(row, col)/(float)max_occupancy;
+                color = config.color_palette.sample_color(density);
+
+                // Use ANSI escape sequence to set the RGB color of the background.
+                // Most modern terminals should support this.
+                out << "\033[48;2;"
+                    << unsigned(color.red)   << ";"
+                    << unsigned(color.green) << ";"
+                    << unsigned(color.blue)  << "m";
+
+                out << "  ";
+
+                // Reset color back to neutral.
+                out << "\e[0m";
+            }
+            out << "\n";
+        }
+    }
+};
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "drawing/generic.hpp"
 #include "drawing/stb_image.hpp"
 #include "drawing/svg.hpp"
+#include "drawing/term.hpp"
 
 void print_parsing_error(const Status& status) {
     std::cerr << "Error:" << status.line << ":" << status.col << ": " << status.error_message << "\n";
@@ -53,6 +54,7 @@ std::string get_image_extension(ImageFormat format) {
         { ImageFormat::bmp, ".bmp" },
         { ImageFormat::tga, ".tga" },
         { ImageFormat::svg, ".svg" },
+        { ImageFormat::term, ".term" },
     };
     return extensions.at(format);
 }
@@ -118,6 +120,9 @@ void draw_grid(const Grid& grid, ImageConfig& image_config, const CmdOptions& op
 
     if (image_config.format == ImageFormat::svg) {
         GenericDrawer<SvgImage> drawer;
+        drawer(grid, image_config);
+    } else if (image_config.format == ImageFormat::term) {
+        TermDrawer drawer;
         drawer(grid, image_config);
     } else {
         GenericDrawer<StbImage> drawer;


### PR DESCRIPTION
Allow `marc -f term` to output the matrix image into the current terminal. It uses [this sequence](https://en.wikipedia.org/wiki/ANSI_escape_code#24-bit) to render colored blocks.